### PR TITLE
fix browsersync in firefox

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,17 @@ var startSync = function(){
   if(config.env == 'development' && !browserSync.active){
 
     browserSync.init({
-
+      
+      notify: false,
+      snippetOptions: {
+        rule: {
+          match: '<span id="browser-sync-binding"></span>',
+          fn: function (snippet) {
+            return snippet;
+          }
+        }
+      },
+      
       proxy: "localhost:3000",
       files: [
         'public/**/*.{js,css,html}',

--- a/server/views/layouts/default.html
+++ b/server/views/layouts/default.html
@@ -4,6 +4,7 @@
   {% include "../includes/head.html" %}
 </head>
 <body unresolved class="fullbleed layout vertical">
+<span id="browser-sync-binding"></span>
   {% block content %}{% endblock %}
   {% include "../includes/foot.html" %}
 </body>


### PR DESCRIPTION
Browsersync needs an element to grab onto, otherwise it tries to grab onto comments in some files, and errors are thrown.
